### PR TITLE
Refactor CI workflow to read registry metadata from environment variables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,6 @@ on:
       - main
       - dev
 
-env:
-  IMAGE_NAME: cinema-app
-  REGISTRY_USERNAME: charlunn
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,6 +18,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Load registry configuration
+        shell: bash
+        run: |
+          echo "IMAGE_NAME=${{ vars.IMAGE_NAME }}" >> "$GITHUB_ENV"
+          echo "REGISTRY_USERNAME=${{ vars.REGISTRY_USERNAME }}" >> "$GITHUB_ENV"
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -61,6 +63,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Load registry configuration
+        shell: bash
+        run: |
+          echo "IMAGE_NAME=${{ vars.IMAGE_NAME }}" >> "$GITHUB_ENV"
+          echo "REGISTRY_USERNAME=${{ vars.REGISTRY_USERNAME }}" >> "$GITHUB_ENV"
 
       - name: Download image artifact
         uses: actions/download-artifact@v4

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -69,6 +69,12 @@
     - 新增 .env.example（APP_PORT、DB_DSN、LOG_LEVEL、ENV、CORS 源等）
     - 程序读取 env；默认值保持与当前行为兼容
 
+## 部署前置条件
+
+- 在 GitHub Environment（或仓库级环境变量）中配置以下变量，确保工作流在推送容器镜像时复用统一的仓库信息：
+  - `REGISTRY_USERNAME`
+  - `IMAGE_NAME`
+
 交付物清单（新增为主）
 - 新接口的 Swagger 文档（swag 注释或 openapi.yml）
 - 统一响应结构与错误码枚举（仅用于新增接口）


### PR DESCRIPTION
## Summary
- update the CI workflow to load the registry username and image name from repository/environment variables at runtime instead of hardcoded values
- document the requirement to configure the registry-related GitHub Environment variables before deploying

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68e200eb9fc48327a475d32a2c9c4ca8