### PR TITLE
Fix default registry metadata in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Load registry configuration
         shell: bash
         run: |
-          echo "IMAGE_NAME=${{ vars.IMAGE_NAME }}" >> "$GITHUB_ENV"
-          echo "REGISTRY_USERNAME=${{ vars.REGISTRY_USERNAME }}" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME=${{ vars.IMAGE_NAME || 'cinema' }}" >> "$GITHUB_ENV"
+          echo "REGISTRY_USERNAME=${{ vars.REGISTRY_USERNAME || github.repository_owner }}" >> "$GITHUB_ENV"
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -67,8 +67,8 @@ jobs:
       - name: Load registry configuration
         shell: bash
         run: |
-          echo "IMAGE_NAME=${{ vars.IMAGE_NAME }}" >> "$GITHUB_ENV"
-          echo "REGISTRY_USERNAME=${{ vars.REGISTRY_USERNAME }}" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME=${{ vars.IMAGE_NAME || 'cinema' }}" >> "$GITHUB_ENV"
+          echo "REGISTRY_USERNAME=${{ vars.REGISTRY_USERNAME || github.repository_owner }}" >> "$GITHUB_ENV"
 
       - name: Download image artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- ensure the CI workflow falls back to default values for IMAGE_NAME and REGISTRY_USERNAME when repository variables are absent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e20348c1208327ac1dc3d6a640a5ca