### PR TITLE
Run CI/CD on self-hosted runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       IMAGE_TAG: ${{ github.sha }}
     steps:
@@ -60,11 +60,14 @@ jobs:
           retention-days: 1
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     env:
       IMAGE_TAG: ${{ github.sha }}
       DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+    concurrency:
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- update the CI build and deploy jobs to execute on the self-hosted runner
- add concurrency control to the deploy job to avoid overlapping releases

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68e22e9f364c8327a02ff25d473df0d0