### PR TITLE
Default frontend API fallback to port 8080 backend

### DIFF
--- a/cinema/.env
+++ b/cinema/.env
@@ -14,5 +14,5 @@ DB_URL=postgres://cinema:cinema@db:5432/cinema?sslmode=disable
 BOXOFFICE_URL=https://mock.apifox.com/m1/4288164-0-default
 BOXOFFICE_API_KEY=mock-key
 
-# 前端在浏览器中访问的后端地址（宿主机端口）
-FRONTEND_API_BASE_URL=http://localhost:8080
+# 前端可选的后端访问地址（为空时默认指向当前主机的 8080 端口）
+FRONTEND_API_BASE_URL=

--- a/cinema/index.html
+++ b/cinema/index.html
@@ -162,7 +162,7 @@
             <!-- 无结果提示 -->
             <div id="no-results" class="hidden text-center py-12">
                 <p class="text-gray-400 text-xl">😔 未找到符合条件的电影。</p>
-                <p class="text-gray-500 mt-2">请尝试更改您的搜索条件或检查后端服务是否运行在 **http://localhost:8080**。</p>
+                <p class="text-gray-500 mt-2">请尝试更改您的搜索条件或检查后端服务是否运行在 <span id="backend-url-hint" class="font-semibold"></span>。</p>
             </div>
         </section>
 
@@ -284,7 +284,37 @@
     <script src="config.js"></script>
     <script>
         // --- 全局配置 ---
-        const API_BASE_URL = (window.APP_CONFIG && window.APP_CONFIG.API_BASE_URL) || 'http://localhost:8080';
+        const rawConfiguredBaseUrl = (window.APP_CONFIG && window.APP_CONFIG.API_BASE_URL) ? window.APP_CONFIG.API_BASE_URL.trim() : '';
+
+        function normalizeBaseUrl(url) {
+            if (!url) return '';
+            return url.replace(/\/+$/, '');
+        }
+
+        function deriveDefaultApiBaseUrl() {
+            if (!window.location || !window.location.origin || window.location.origin === 'null') {
+                return '';
+            }
+
+            try {
+                const candidate = new URL(window.location.origin);
+                candidate.port = '8080';
+                return candidate.origin;
+            } catch (error) {
+                console.warn('无法推断默认的后端地址，将继续使用当前站点。', error);
+                return '';
+            }
+        }
+
+        const configuredBaseUrl = normalizeBaseUrl(rawConfiguredBaseUrl);
+        const derivedBaseUrl = normalizeBaseUrl(deriveDefaultApiBaseUrl());
+        const fallbackSameOrigin = (window.location && window.location.origin && window.location.origin !== 'null') ? normalizeBaseUrl(window.location.origin) : '';
+        const API_BASE_URL = configuredBaseUrl || derivedBaseUrl || fallbackSameOrigin;
+        const DEFAULT_BACKEND_DISPLAY = configuredBaseUrl || derivedBaseUrl || fallbackSameOrigin || '同源端口 8080';
+        const backendUrlHintElement = document.getElementById('backend-url-hint');
+        if (backendUrlHintElement) {
+            backendUrlHintElement.textContent = DEFAULT_BACKEND_DISPLAY;
+        }
         const API_MOVIES_ENDPOINT = '/movies';
         const PAGE_SIZE = 12; 
         const RATING_VALUES = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0];
@@ -381,7 +411,7 @@
             } catch (error) {
                 console.error('API Error:', error);
                 // 重点：当遇到网络错误（如 Failed to fetch）时，给出明确的 CORS/服务器检查提示
-                showCustomAlert(`搜索 API 请求失败。错误信息: ${error.message}。请检查后端服务 (http://localhost:8080) 是否运行正常，以及是否配置了 CORS 跨域访问策略。`);
+                showCustomAlert(`搜索 API 请求失败。错误信息: ${error.message}。请检查后端服务 (${DEFAULT_BACKEND_DISPLAY}) 是否运行正常，以及是否配置了 CORS 跨域访问策略。`);
                 return { items: [], nextCursor: null, error: error.message }; 
             }
         }

--- a/cinema/openapi.yml
+++ b/cinema/openapi.yml
@@ -11,8 +11,18 @@ info:
     - Rating aggregation returns `{average, count}`, with average rounded to **1 decimal place**.
     - List search supports `q | year | distributor | budget | mpaRating | genre | limit | cursor`, pagination response is fixed as `items[] + nextCursor`.
 servers:
-  - url: https://api.example.com
-  - url: http://localhost:8080
+  - url: "{scheme}://{hostname}:{port}"
+    description: Backend reachable on the same host as the frontend, defaulting to port 8080.
+    variables:
+      scheme:
+        default: http
+        enum: [http, https]
+      hostname:
+        default: backend-host
+        description: Deployment hostname.
+      port:
+        default: "8080"
+        description: Backend service port (defaults to 8080).
 tags:
   - name: Movies
   - name: Ratings


### PR DESCRIPTION
## Summary
- derive the frontend API base URL to default to the current host on port 8080 when no override is configured
- clarify the frontend configuration comment about the default backend resolution
- update the OpenAPI servers list to advertise the host-with-port configuration instead of localhost

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e239423bb48327a4505407811de3d9